### PR TITLE
fix: apply overwrite logic to object key persistence

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,9 @@ export function createStatePersistence<S extends StateTree = StateTree>(
 				const savedState = typeof savedValue === 'object' ? savedValue : deserialize(savedValue)
 
 				if (stateKey) {
-					context.store.$patch({ [stateKey]: savedState })
+					overwrite
+						? (context.store.$state[stateKey] = savedState)
+						: context.store.$patch(savedState)
 				}
 				else {
 					overwrite


### PR DESCRIPTION
# Pull Request 🚀

## Description
<!-- Please include a summary of the change and what issue is fixed. -->

This PR extends the `overwrite` functionality to support object key persistence in the Pinia plugin. Previously, the `overwrite` option did not apply to individual keys specified in the `key` object for persistence. This fix ensures consistent behavior across all persistence configurations.

Fixes: #5

## Conventional Commit Type
<!-- Ensure the PR title matches the Conventional Commit type. -->
- [x] fix: A bug fix
- [ ] feat: A new feature
- [ ] docs: Documentation changes only
- [ ] style: Code style changes (e.g., formatting)
- [ ] refactor: Code refactoring without changing behavior
- [ ] perf: Performance improvements
- [ ] test: Adding or updating tests
- [ ] chore: Build process or auxiliary tool changes
- [ ] ci: Changes to CI configuration
- [ ] build: Changes affecting build system or dependencies

## Checklist
- [x] My commit message follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] I have updated the documentation as necessary.

## Additional Notes
<!-- Add any other information or screenshots about the PR here. -->

This fix improves flexibility and ensures the `overwrite` functionality is applied consistently to all persistence configurations, including custom keys specified through the `key` option.

