### PR TITLE
feat(persistence): add support for multiple storages

### DIFF
--- a/docs/guide/advance-usage.md
+++ b/docs/guide/advance-usage.md
@@ -40,7 +40,7 @@ This is particularly helpful in batch updates or custom save operations that byp
 
 ## Object Key Persistence
 
-The plugin now supports persisting state properties on separate keys when an object is provided for the `key` option. This allows finer control over how state properties are stored.
+The plugin supports persisting state properties on separate keys when an object is provided for the `key` option. This allows finer control over how state properties are stored.
 
 ### Example Configuration
 
@@ -67,6 +67,45 @@ export const useExampleStore = defineStore('example', {
 - Properties not included in the `key` object will fall back to the default storage behavior and will use `store.$id` as the storage key.
 - This approach is particularly useful for large stores where persisting state properties to different storage keys is needed.
 
+## Multiple Storage Support
+
+The plugin supports persisting state properties to multiple storages by allowing the `persist` option to accept an array of persistence configurations. This enables fine-grained control over where and how state properties are stored.
+
+### Example Configuration
+
+```typescript
+import { defineStore } from 'pinia'
+
+export const useExampleStore = defineStore('example', {
+	state: () => ({
+		userId: 1,
+		token: 'Bearer ...',
+		preferences: { theme: 'dark' },
+	}),
+	persist: [
+		{
+			key: 'user-data',
+			storage: localStorage,
+			include: ['userId', 'token'],
+		},
+		{
+			key: 'preferences-storage',
+			storage: sessionStorage,
+			include: ['preferences'],
+		}
+	],
+})
+```
+
+### Behavior
+
+- Each persistence configuration applies to specific state properties based on the `include` and `exclude` options.
+- Different storages can be used for different pieces of state (e.g., `localStorage` for authentication and `sessionStorage` for UI preferences).
+- When multiple persistence configurations apply to the same state keys, they will be processed in order, and the last configuration may overwrite earlier ones.
+- The `overwrite` option is not allowed as persistence is sequential, with later configurations overriding previous ones.
+
+This feature is particularly useful for applications requiring fine control over storage strategies, such as segregating sensitive authentication data from non-sensitive UI preferences.
+
 ## Conclusion
 
-The `$restore` and `$persist` functions, along with comprehensive plugin configurations like object key persistence, provide flexibility and power for state management. By hooking into Pinia's `$subscribe`, most persistence needs are automatically managed, ensuring seamless state synchronization. These tools offer additional control for edge cases, such as handling manual updates to storage, unique custom scenarios, or persisting individual state properties to specific keys. Leverage these options to build sophisticated applications with reliable persistence and efficient state synchronization.
+The `$restore` and `$persist` functions, along with comprehensive plugin configurations like object key persistence and multiple storage support, provide flexibility and power for state management. By hooking into Pinia's `$subscribe`, most persistence needs are automatically managed, ensuring seamless state synchronization. These tools offer additional control for edge cases, such as handling manual updates to storage, unique custom scenarios, or persisting individual state properties to specific keys and storages. Leverage these options to build sophisticated applications with reliable persistence and efficient state synchronization.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import type { PiniaPlugin, PiniaPluginContext, StateTree } from 'pinia'
-import type { GlobalPersistOptions, Storage } from './types.js'
+import type { GlobalPersistOptions, PersistOptions, Storage } from './types.js'
 import { applyStateFilter, createLogger, getObjectDiff, isPromise, queueTask } from './utils.js'
 
 export function createStatePersistence<S extends StateTree = StateTree>(
@@ -17,10 +17,8 @@ export function createStatePersistence<S extends StateTree = StateTree>(
 			log.info('Using localStorage as the default storage.')
 			return window.localStorage
 		}
-		else {
-			log.error('No valid storage found. PersistPlugin will be disabled.')
-			return null
-		}
+		log.error('No valid storage found. PersistPlugin will be disabled.')
+		return null
 	}
 
 	return (context: PiniaPluginContext) => {
@@ -30,144 +28,154 @@ export function createStatePersistence<S extends StateTree = StateTree>(
 			return
 		}
 
-		const {
-			key = context.store.$id,
-			overwrite = false,
-			storage = detectStorage(),
-			filter = () => true,
-			serialize = JSON.stringify,
-			deserialize = JSON.parse,
-			deepCopy = false,
-			clientOnly = false,
-			include = null,
-			exclude = null,
-		} = { ...{ ...globalOptions, key: undefined }, ...(typeof storeOptions === 'object' && storeOptions) }
+		// Normalize persist options to an array
+		const persistOptionsArray: Array<PersistOptions<S>> = Array.isArray(storeOptions)
+			? storeOptions
+			: storeOptions === true
+				? [{}]
+				: [storeOptions]
 
-		if (!storage || ((clientOnly || storage.constructor.name.includes('LocalForage')) && typeof window === 'undefined')) {
-			log.warn(`Skipping persistence for ${context.store.$id}: Storage unavailable or client-only restriction applied.`)
-			return
-		}
+		// Process each persist configuration
+		persistOptionsArray.forEach((options) => {
+			const {
+				key = context.store.$id,
+				overwrite = false,
+				storage = detectStorage(),
+				filter = () => true,
+				serialize = JSON.stringify,
+				deserialize = JSON.parse,
+				deepCopy = false,
+				clientOnly = false,
+				include = null,
+				exclude = null,
+			} = { ...{ ...globalOptions, key: undefined }, ...options }
 
-		// Combine global prefix with store-specific key
-		const getPrefixedKey = (storeKey: string) =>
-			globalOptions.key ? `${globalOptions.key}:${storeKey}` : storeKey
-
-		let isRestoringState: boolean
-		const loadState = () => {
-			log.info(`Initiating state restoration for store: ${context.store.$id}`)
-			const tasks: Promise<void>[] = []
-			let stateToRestore: Record<string, any> = {}
-
-			const getItem = (key: string) => {
-				try {
-					const result = storage.getItem(getPrefixedKey(key))
-					if (isPromise(result)) {
-						const task = queueTask(queues, key, async () => await result)
-						tasks.push(task)
-						return task
-					}
-					return result
-				}
-				catch (error) {
-					log.error(`Failed to retrieve item ${key}:`, error)
-				}
-			}
-
-			const restoreState = (state: Record<string, any>) => {
-				if (!state || Object.keys(state).length === 0) {
-					log.warn(`No state to restore for store: ${context.store.$id}`)
-					return
-				}
-				isRestoringState = true
-				if (overwrite) {
-					log.info(`Overwriting state for store: ${context.store.$id}`)
-					context.store.$state = state
-				}
-				else {
-					log.info(`Merging restored state into store: ${context.store.$id}`)
-					context.store.$patch(state)
-				}
-				isRestoringState = false
-			}
-
-			const resolveAndDeserialize = (storageKey: string, stateKey?: string) => {
-				const processValue = (value: any) => {
-					if (value) {
-						const deserializedValue = typeof value === 'object' ? value : deserialize(value)
-						stateKey ? (stateToRestore[stateKey] = deserializedValue) : (stateToRestore = deserializedValue)
-					}
-					else {
-						log.error(`No value found for key: ${storageKey}`)
-					}
-				}
-				const savedValue = getItem(storageKey)
-				isPromise(savedValue) ? savedValue.then(processValue) : processValue(savedValue)
-			}
-
-			resolveAndDeserialize(typeof key === 'string' ? key : context.store.$id)
-			if (typeof key === 'object') {
-				Object.entries(key).forEach(([stateKey, storageKey]) => {
-					resolveAndDeserialize(storageKey, stateKey)
-				})
-			}
-
-			if (tasks.length) {
-				return Promise.all(tasks).then(() => {
-					restoreState(stateToRestore)
-					log.info(`Async storage state restoration complete for store: ${context.store.$id}`)
-				})
-			}
-
-			restoreState(stateToRestore)
-			log.info(`Synchronous storage state restoration complete for store: ${context.store.$id}`)
-		}
-
-		// Persist state on mutation
-		const persistState = (mutation: any, state: S) => {
-			if (!filter(mutation, state) || isRestoringState) {
-				log.info(`Skipping persistence for store: ${context.store.$id}. Mutation:`, mutation)
+			if (!storage || ((clientOnly || storage.constructor.name.includes('LocalForage')) && typeof window === 'undefined')) {
+				log.warn(`Skipping persistence for ${context.store.$id}: Storage unavailable or client-only restriction applied.`)
 				return
 			}
 
-			const tasks: Promise<void>[] = []
-			const filteredState = applyStateFilter(state, include, exclude)
-			const setItem = (key: string, value: string) => {
-				try {
-					const result = storage.setItem(getPrefixedKey(key), deepCopy ? deserialize(value) : value)
-					if (isPromise(result)) {
-						const task = queueTask(queues, key, async () => await result)
-						tasks.push(task)
+			// Combine global prefix with store-specific key
+			const getPrefixedKey = (storeKey: string) =>
+				globalOptions.key ? `${globalOptions.key}:${storeKey}` : storeKey
+
+			let isRestoringState = false
+			const loadState = () => {
+				log.info(`Initiating state restoration for store: ${context.store.$id}`)
+				const tasks: Promise<void>[] = []
+				let stateToRestore: Record<string, any> = {}
+
+				const getItem = (key: string) => {
+					try {
+						const result = storage.getItem(getPrefixedKey(key))
+						if (isPromise(result)) {
+							const task = queueTask(queues, key, async () => await result)
+							tasks.push(task)
+							return task
+						}
+						return result
+					}
+					catch (error) {
+						log.error(`Failed to retrieve item ${key}:`, error)
 					}
 				}
-				catch (error) {
-					log.error(`Failed to persist state for key ${key}:`, error)
+
+				const restoreState = (state: Record<string, any>) => {
+					if (!state || Object.keys(state).length === 0) {
+						log.warn(`No state to restore for store: ${context.store.$id}`)
+						return
+					}
+					isRestoringState = true
+					if (overwrite) {
+						log.info(`Overwriting state for store: ${context.store.$id}`)
+						context.store.$state = state
+					}
+					else {
+						log.info(`Merging restored state into store: ${context.store.$id}`)
+						context.store.$patch(state)
+					}
+					isRestoringState = false
 				}
+
+				const resolveAndDeserialize = (storageKey: string, stateKey?: string) => {
+					const processValue = (value: any) => {
+						if (value) {
+							const deserializedValue = typeof value === 'object' ? value : deserialize(value)
+							stateKey ? (stateToRestore[stateKey] = deserializedValue) : (stateToRestore = deserializedValue)
+						}
+						else {
+							log.error(`No value found for key: ${storageKey}`)
+						}
+					}
+					const savedValue = getItem(storageKey)
+					isPromise(savedValue) ? savedValue.then(processValue) : processValue(savedValue)
+				}
+
+				resolveAndDeserialize(typeof key === 'string' ? key : context.store.$id)
+				if (typeof key === 'object') {
+					Object.entries(key).forEach(([stateKey, storageKey]) => {
+						resolveAndDeserialize(storageKey, stateKey)
+					})
+				}
+
+				if (tasks.length) {
+					return Promise.all(tasks).then(() => {
+						restoreState(stateToRestore)
+						log.info(`Async storage state restoration complete for store: ${context.store.$id}`)
+					})
+				}
+
+				restoreState(stateToRestore)
+				log.info(`Synchronous storage state restoration complete for store: ${context.store.$id}`)
 			}
 
-			if (typeof key === 'string') {
-				setItem(key, serialize(filteredState))
-			}
-			else {
-				setItem(context.store.$id, serialize(getObjectDiff(filteredState, key)))
-				for (const [stateKey, storageKey] of Object.entries(key)) {
-					if (filteredState[stateKey] !== undefined) {
-						setItem(storageKey, serialize(filteredState[stateKey]))
+			// Persist state on mutation
+			const persistState = (mutation: any, state: S) => {
+				if (!filter(mutation, state) || isRestoringState) {
+					log.info(`Skipping persistence for store: ${context.store.$id}. Mutation:`, mutation)
+					return
+				}
+
+				const tasks: Promise<void>[] = []
+				const filteredState = applyStateFilter(state, include, exclude)
+				const setItem = (key: string, value: string) => {
+					try {
+						const result = storage.setItem(getPrefixedKey(key), deepCopy ? deserialize(value) : value)
+						if (isPromise(result)) {
+							const task = queueTask(queues, key, async () => await result)
+							tasks.push(task)
+						}
+					}
+					catch (error) {
+						log.error(`Failed to persist state for key ${key}:`, error)
 					}
 				}
-			}
-			if (tasks.length) {
-				return Promise.all(tasks).then(() => {
-					log.info(`Async state persistence complete for store: ${context.store.$id}`)
-				})
-			}
-			log.info(`Synchronous state persistence complete for store: ${context.store.$id}`)
-		}
 
-		context.store.$restore = loadState
-		context.store.$persist = () =>
-			persistState({ type: 'persist', storeId: context.store.$id }, context.store.$state)
+				if (typeof key === 'string') {
+					setItem(key, serialize(filteredState))
+				}
+				else {
+					setItem(context.store.$id, serialize(getObjectDiff(filteredState, key)))
+					for (const [stateKey, storageKey] of Object.entries(key)) {
+						if (filteredState[stateKey] !== undefined) {
+							setItem(storageKey, serialize(filteredState[stateKey]))
+						}
+					}
+				}
+				if (tasks.length) {
+					return Promise.all(tasks).then(() => {
+						log.info(`Async state persistence complete for store: ${context.store.$id}`)
+					})
+				}
+				log.info(`Synchronous state persistence complete for store: ${context.store.$id}`)
+			}
 
-		loadState()
-		context.store.$subscribe(persistState, { flush: 'sync' })
+			context.store.$restore = loadState
+			context.store.$persist = () =>
+				persistState({ type: 'persist', storeId: context.store.$id }, context.store.$state)
+
+			loadState()
+			context.store.$subscribe(persistState, { flush: 'sync' })
+		})
 	}
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,6 @@ declare module 'pinia' {
 	}
 	// eslint-disable-next-line unused-imports/no-unused-vars
 	export interface DefineStoreOptionsBase<S extends StateTree, Store> {
-		persist?: boolean | PersistOptions<S>
+		persist?: boolean | PersistOptions<S> | Omit<PersistOptions<S>, 'overwrite'>[]
 	}
 }


### PR DESCRIPTION
### **Pull Request Description**  
#### **Description**  
This PR introduces support for multiple storage configurations in Pinia state persistence. The `persist` option now accepts an array, allowing different state properties to be stored in different storages.  

Fixes: #14 

#### **Conventional Commit Type**  
- [x] feat: A new feature  

#### **Checklist**  
- [x] My commit message follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification.  
- [x] My code follows the style guidelines of this project.  
- [x] I have performed a self-review of my code.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have added tests that prove my fix is effective or that my feature works.  
- [x] New and existing unit tests pass locally with my changes.  
- [x] I have updated the documentation as necessary.  

#### **Additional Notes**  
This enhancement provides greater flexibility for applications that need fine-grained control over storage strategies, such as separating authentication tokens from UI preferences. 🚀

